### PR TITLE
Remote Undesired Spammy `print("hi")` From The Codebase

### DIFF
--- a/Sources/CodableWrappers/OptionalWrappers.swift
+++ b/Sources/CodableWrappers/OptionalWrappers.swift
@@ -41,7 +41,6 @@ extension KeyedDecodingContainer {
 extension KeyedEncodingContainer {
     // Used to make make sure OptionalCodingWrappers encode no value when it's wrappedValue is nil.
     public mutating func encode<T>(_ value: T, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable, T: OptionalCodingWrapper {
-        print("hi")
         // Currently uses Mirror...this should really be avoided, but I'm not sure there's another way to do it cleanly.
         let mirror = Mirror(reflecting: value.wrappedValue)
         guard mirror.displayStyle != .optional || !mirror.children.isEmpty else {
@@ -95,7 +94,6 @@ extension KeyedDecodingContainer {
 extension KeyedEncodingContainer {
     // Used to make make sure OptionalCodingWrappers encode no value when it's wrappedValue is nil.
     public mutating func encode<T>(_ value: T, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable, T: OmitableFromCoding {
-        print("hi")
         return
     }
 }


### PR DESCRIPTION
Hello! 👋 

These probably weren't meant to be committed, so I'm removing them. They're printed a lot during execution 😅 

I'd really appreciate if this PR could make its way to a release soon 🙏 
Thank you!