### PR TITLE
Limit EmptyFloat16 availability to iOS 14.0 and up

### DIFF
--- a/Sources/CodableWrappers/Convenience/EmptyDefaults.swift
+++ b/Sources/CodableWrappers/Convenience/EmptyDefaults.swift
@@ -82,6 +82,7 @@ public struct EmptyFloat: FallbackValueProvider {
 
 #if swift(>=5.4) && !os(macOS)
 /// Empty FallbackValueProvider for Float16: 0
+@available(iOS 14.0, *)
 public struct EmptyFloat16: FallbackValueProvider {
     public static var defaultValue: Float16 { 0 }
 }


### PR DESCRIPTION
This solves an issue with using this library with Xcode 12.5 when building for an earlier version of iOS than 14.0