### PR TITLE
Fix: Float16 support

### DIFF
--- a/Sources/CodableWrappers/Convenience/EmptyDefaults.swift
+++ b/Sources/CodableWrappers/Convenience/EmptyDefaults.swift
@@ -80,7 +80,7 @@ public struct EmptyFloat: FallbackValueProvider {
     public static var defaultValue: Float { 0 }
 }
 
-#if swift(>=5.4)
+#if swift(>=5.4) && !arch(x86_64)
 /// Empty FallbackValueProvider for Float16: 0
 @available(swift 5.4)
 @available(iOS 14, macOS 11, tvOS 14.0, watchOS 7.0, macCatalyst 14.5, *)

--- a/Tests/CodableWrappersTests/Decoder/EmptyDefaultsDecodingTests.swift
+++ b/Tests/CodableWrappersTests/Decoder/EmptyDefaultsDecodingTests.swift
@@ -104,7 +104,8 @@ private struct DefaultDecodingModel: Codable, Equatable {
     @FallbackDecoding<EmptyFloat>
     var float: Float
 
-    #if swift(>=5.4) && !os(macOS)
+    #if swift(>=5.4) && !arch(x86_64)
+    @available(iOS 14, macOS 11, tvOS 14.0, watchOS 7.0, macCatalyst 14.5, *)
     @FallbackDecoding<EmptyFloat16>
     var float16: Float16
     #else

--- a/Tests/CodableWrappersTests/Encoder/EmptyDefaultsEncodingTests.swift
+++ b/Tests/CodableWrappersTests/Encoder/EmptyDefaultsEncodingTests.swift
@@ -121,7 +121,8 @@ private struct DefaultEncodingModel: Codable, Equatable {
     @FallbackEncoding<EmptyFloat>
     var float: Float?
 
-    #if swift(>=5.4) && !os(macOS)
+    #if swift(>=5.4) && !arch(x86_64)
+    @available(iOS 14, macOS 11, tvOS 14.0, watchOS 7.0, macCatalyst 14.5, *)
     @FallbackEncoding<EmptyFloat16>
     var float16: Float16?
     #else


### PR DESCRIPTION
Apple responded to my feedback with:
> Float16 isn’t supported on Intel Macs, but should be available on Apple Silicon Macs.

Introduced these warnings for the test cases:
> warning: conformance of 'Float16' to ‘Encodable' is only available in macOS 11.0 or newer
> warning: conformance of 'Float16' to ‘Decodable' is only available in macOS 11.0 or newer
> warning: conformance of 'Float16' to ‘Encodable' is only available in Mac Catalyst 14.0 or newer
> warning: conformance of 'Float16' to 'Decodable' is only available in Mac Catalyst 14.0 or newer

Fixes https://github.com/GottaGetSwifty/CodableWrappers/issues/13.

**Note:** you have write access to edit my branch.