### PR TITLE
Implement CurrentPathCoding

### DIFF
--- a/Sources/CodableWrappers/Convenience/CustomWrappers.swift
+++ b/Sources/CodableWrappers/Convenience/CustomWrappers.swift
@@ -163,3 +163,9 @@ public typealias LossyDictionaryDecoding<T: Decodable, Key: Decodable & Hashable
 /// Encodes a nil value in a singleValueContainer using `encodeNil` rather than it being omitted.
 /// - note This uses Mirror to check for nil so should not be used in high performance scenarios. This is done in order to check for nil without short circuiting nested Error handling. If there is a better way please submit a pull request / issue :)
 public typealias EncodeNulls<T: Encodable & ExpressibleByNilLiteral> = EncodingUses<NullStaticEncoder<T>>
+
+
+
+public typealias CurrentPathEncoding<T: Encodable> = EncodingUses<CurrentPathStaticEncoder<T>>
+public typealias CurrentPathDecoding<T: Decodable> = DecodingUses<CurrentPathStaticDecoder<T>>
+public typealias CurrentPathCoding<T: Codable> = CodingUses<CurrentPathStaticCoder<T>>

--- a/Sources/CodableWrappers/StaticCoders/CurrentPathCoding.swift
+++ b/Sources/CodableWrappers/StaticCoders/CurrentPathCoding.swift
@@ -1,0 +1,80 @@
+//
+//  CurrentPathCoding.swift
+//  
+//
+//  Created by KY1VSTAR on 30.04.2021.
+//
+
+import Foundation
+
+public protocol AnyCurrentPathEncoder {
+    associatedtype T: Encodable
+    static func encode(value: T, to encoder: Encoder) throws
+}
+
+public protocol AnyCurrentPathDecoder {
+    associatedtype T: Decodable
+    static func decode(from decoder: Decoder) throws -> T
+}
+
+public struct CurrentPathStaticEncoder<T: Encodable>: StaticEncoder, AnyCurrentPathEncoder {
+    public static func encode(value: T, to encoder: Encoder) throws {
+        try value.encode(to: encoder)
+    }
+}
+
+public struct CurrentPathStaticDecoder<T: Decodable>: StaticDecoder, AnyCurrentPathDecoder {
+    public static func decode(from decoder: Decoder) throws -> T {
+        try T.init(from: decoder)
+    }
+}
+
+public struct CurrentPathStaticCoder<T: Codable>: StaticCoder, AnyCurrentPathEncoder, AnyCurrentPathDecoder {
+    public static func decode(from decoder: Decoder) throws -> T {
+        try T.init(from: decoder)
+    }
+    
+    public static func encode(value: T, to encoder: Encoder) throws {
+        try value.encode(to: encoder)
+    }
+}
+
+extension KeyedEncodingContainer {
+    public mutating func encode<T>(_ value: T, forKey key: Key) throws where T: StaticEncoderWrapper, T.CustomEncoder: AnyCurrentPathEncoder {
+        let extractor = EncoderExtractor()
+        try? encode(extractor, forKey: key)
+        
+        guard let encoder = extractor.encoder else {
+            throw EncodingError.invalidValue(value, .init(codingPath: codingPath, debugDescription: "Failed to encode \(T.self)"))
+        }
+
+        try T.CustomEncoder.encode(value: value.wrappedValue, to: encoder)
+    }
+}
+
+extension KeyedDecodingContainer {
+    public func decode<T>(_: T.Type, forKey key: Key) throws -> T where T: StaticDecoderWrapper, T.CustomDecoder: AnyCurrentPathDecoder {
+        let anyKey = allKeys.first ?? key
+        let extractor = try decode(DecoderExtractor.self, forKey: anyKey)
+        return T.init(wrappedValue: try T.CustomDecoder.decode(from: extractor.decoder))
+    }
+}
+
+private final class EncoderExtractor: Encodable {
+    var encoder: Encoder?
+    
+    func encode(to encoder: Encoder) throws {
+        self.encoder = encoder
+        throw DummyError()
+    }
+}
+
+private struct DummyError: Error {}
+
+private struct DecoderExtractor: Decodable {
+    var decoder: Decoder
+    
+    init(from decoder: Decoder) throws {
+        self.decoder = decoder
+    }
+}


### PR DESCRIPTION
Hey! It is not final version of intended PR, but I wanted to make sure that author is interested in such feature. Implemented `@CurrentPathCoding` wrapper allows this JSON structure:
```json
{
    "title": "Cool title",
    "authorName": "John",
    "authorEmail": "john@doe.com"
}
```
to be mapped to such model:
```swift
struct Author: Codable {
    var authorName: String
    var authorEmail: String
}

struct Article: Codable {
    var title: String
    @CurrentPathCoding
    var author: Author
}
```
If you can approve that such wrapper has the right to life and you would merge it, I'll add documentation and tests and then finalise the PR.