### PR TITLE
Remove use of Mirror in Optional nil check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ struct MyType: Codable {
     var createdAt: Date
 
     @OptionalCoding<SecondsSince1970DateCoding>
-    var updatedAt: Date
+    var updatedAt: Date?
 }
 ```
 

--- a/Sources/CodableWrappers/Core/OptionalWrappers.swift
+++ b/Sources/CodableWrappers/Core/OptionalWrappers.swift
@@ -31,9 +31,7 @@ extension KeyedEncodingContainer {
     // Used to make make sure OptionalCodingWrappers encode no value when it's wrappedValue is nil.
     public mutating func encode<T>(_ value: T, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable, T: OptionalEncodingWrapper {
 
-        // Currently uses Mirror...this should really be avoided, but I'm not sure there's another way to do it cleanly/safely.
-        let mirror = Mirror(reflecting: value.wrappedValue)
-        guard mirror.displayStyle != .optional || !mirror.children.isEmpty else {
+        if case Optional<Any>.none = value.wrappedValue as Any {
             return
         }
 


### PR DESCRIPTION
The extension on KeyedEncodingContainer for OptionalEncodingWrapper
checks to make sure that the wrapped value isn't nil before
encoding. It currently constructs a Mirror reflecting the
wrapped value, and inspects that mirror's properties to
detect a nil value.

This commit replaces that code with a cast to Any and a pattern
match against Optional<Any>.none (which is nil).

This commit also adds a missing ? to the property declaration
documenting the new OptionalCoding wrapper.