### PR TITLE
Update CocoaPods version to 2.0.6

### DIFF
--- a/CodableWrappers.podspec
+++ b/CodableWrappers.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CodableWrappers'
-  s.version          = '2.0.0'
+  s.version          = '2.0.6'
   s.swift_versions   = ['5.2']
   s.summary          = 'Simplified Serialization with Property Wrappers'
   s.description      = <<-DESC


### PR DESCRIPTION
The CocoaPods manager doesn't see the  2.0.6 fix because it is not specified in [CodableWrappers.podspec](https://github.com/GottaGetSwifty/CodableWrappers/blob/master/CodableWrappers.podspec)

You can test the difference specifying 

```
pod 'CodableWrappers', :git=>'https://github.com/aserdobintsev/CodableWrappers', :branch=>'fix/cocoapodsVersion'
```
vs
```
pod 'CodableWrappers',
```
