### PR TITLE
Added bypass for `AnyNullEncoder` when wrapped in `Immutable`

### DIFF
--- a/Sources/CodableWrappers/StaticCoders/NullEncoding.swift
+++ b/Sources/CodableWrappers/StaticCoders/NullEncoding.swift
@@ -32,4 +32,9 @@ extension KeyedEncodingContainer {
     public mutating func encode<T>(_ value: T, forKey key: KeyedEncodingContainer<K>.Key) throws where T: OptionalEncodingWrapper & StaticEncoderWrapper, T.CustomEncoder: AnyNullEncoder {
         try T.CustomEncoder.encode(value: value.wrappedValue, to: superEncoder(forKey: key))
     }
+    
+    // Used to bybass the `OptionalCodingWrappers` when wrapped in an `Immutable`, which encodes no value when it's wrappedValue.wrappedValue is nil.
+    public mutating func encode<T>(_ value: T, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable, T: AnyImmutableWrapper, T.T: OptionalEncodingWrapper & StaticEncoderWrapper, T.T.CustomEncoder: AnyNullEncoder {
+        try T.T.CustomEncoder.encode(value: value.wrappedValue.wrappedValue, to: superEncoder(forKey: key))
+    }
 }

--- a/Tests/CodableWrappersTests/Encoder/NullEncodingTests.swift
+++ b/Tests/CodableWrappersTests/Encoder/NullEncodingTests.swift
@@ -41,6 +41,32 @@ class NullEncodingTests: QuickSpec, EncodingTestSpec {
             }
             //MARK: - PListEncoder
         }
+        describe("ImmutableNullEncodingTests") {
+            context("JSONEncoder") {
+                it("EncodesValues") {
+                    expect {_ = try self.jsonEncoder.encode(immutableNullEncodingBasicModel)}.toNot(throwError())
+                    let encodedData = try? self.jsonEncoder.encode(immutableNullEncodingBasicModel)
+                    let encodedString = encodedData.map { String(data: $0, encoding: .utf8)!}
+                    expect(encodedData).toNot(beNil())
+                    expect(encodedString).toNot(beNil())
+
+                    if let actualString = encodedString {
+                        expect(actualString).to(haveEqualLines(to: basicTestJSON))
+                    }
+                }
+                it("EncodesNulls") {
+                    expect {_ = try self.jsonEncoder.encode(immutableNullEncodingEmptyModel)}.toNot(throwError())
+                    let encodedData = try? self.jsonEncoder.encode(immutableNullEncodingEmptyModel)
+                    let encodedString = encodedData.map { String(data: $0, encoding: .utf8)!}
+                    expect(encodedData).toNot(beNil())
+                    expect(encodedString).toNot(beNil())
+
+                    if let actualString = encodedString {
+                        expect(actualString).to(haveEqualLines(to: nullsTestJSON))
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -57,6 +83,20 @@ private struct NullEncodingModel: Codable, Equatable {
 
 private let nullEncodingBasicModel = NullEncodingModel(string: "hi", int: 1)
 private let nullEncodingEmptyModel = NullEncodingModel(string: nil, int: nil)
+
+private struct ImmutableNullEncodingModel: Codable, Equatable {
+
+    @Immutable
+    @EncodeNulls
+    var string: String?
+
+    @Immutable
+    @EncodeNulls
+    var int: Int?
+}
+
+private let immutableNullEncodingBasicModel = ImmutableNullEncodingModel(string: "hi", int: 1)
+private let immutableNullEncodingEmptyModel = ImmutableNullEncodingModel(string: nil, int: nil)
 
 private let basicTestJSON = """
 {


### PR DESCRIPTION
`NullEncoding.swift` includes a specific override of `encode` for `AnyNullEncoder` ([NullEncoding.swift]) to bypass the default behaviour of `OptionalEncodingWrapper` which would otherwise skip the property when the `wrappedValue` is `nil`.

However, `Immutable` also overrides encoding of wrapped `OptionalEncodingWrappers` ([ImmutableWrapper.swift]) to check if the deeply nested `wrappedValue` is `nil` or not, which means the above `AnyNullEncoder` override is never called.

This PR adds an additional bypass for `AnyNullEncoders` wrapped in `AnyImmutableWrapper`.

[NullEncoding.swift]: https://github.com/GottaGetSwifty/CodableWrappers/blob/13045e850d2a11a7e001be35c1dfd13c204ed66c/Sources/CodableWrappers/StaticCoders/NullEncoding.swift#L32
[ImmutableWrapper.swift]: https://github.com/GottaGetSwifty/CodableWrappers/blob/13045e850d2a11a7e001be35c1dfd13c204ed66c/Sources/CodableWrappers/Core/ImmutableWrapper.swift#L56