### PR TITLE
Updated travis-ci config to 🤞 catch broken builds sooner

### DIFF
--- a/.github/workflows/swift.yaml
+++ b/.github/workflows/swift.yaml
@@ -25,6 +25,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build 5.2
-      run: SWIFT_VERSION=5.2 docker build --build-arg SWIFT_VERSION=${SWIFT_VERSION} -t swifty:${SWIFT_VERSION} .
+      run: export SWIFT_VERSION=5.2; podman build --build-arg SWIFT_VERSION=${SWIFT_VERSION} -t "swifty:${SWIFT_VERSION}" .;
     - name: Build 5.6
-      run: SWIFT_VERSION=5.6 docker build --build-arg SWIFT_VERSION=${SWIFT_VERSION} -t swifty:${SWIFT_VERSION} .
+      run: export SWIFT_VERSION=5.6; podman build --build-arg SWIFT_VERSION=${SWIFT_VERSION} -t "swifty:${SWIFT_VERSION}" .;

--- a/.github/workflows/swift.yaml
+++ b/.github/workflows/swift.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Run tests
       run: swift test -v
 
-  build-docker:
+  build-docker-mssv:
 
     runs-on: ubuntu-latest
 
@@ -26,5 +26,12 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build 5.2
       run: export SWIFT_VERSION=5.2; podman build --build-arg SWIFT_VERSION=${SWIFT_VERSION} -t "swifty:${SWIFT_VERSION}" .;
+
+  build-docker-latest:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
     - name: Build 5.6
       run: export SWIFT_VERSION=5.6; podman build --build-arg SWIFT_VERSION=${SWIFT_VERSION} -t "swifty:${SWIFT_VERSION}" .;

--- a/.github/workflows/swift.yaml
+++ b/.github/workflows/swift.yaml
@@ -24,5 +24,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Build
-      run: docker build -t tmp .
+    - name: Build 5.2
+      run: SWIFT_VERSION=5.2 docker build --build-arg SWIFT_VERSION=${SWIFT_VERSION} -t swifty:${SWIFT_VERSION} .
+    - name: Build 5.6
+      run: SWIFT_VERSION=5.6 docker build --build-arg SWIFT_VERSION=${SWIFT_VERSION} -t swifty:${SWIFT_VERSION} .

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,28 @@
+name: Swift
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-mac:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: swift build -v
+    - name: Run tests
+      run: swift test -v
+
+  build-docker:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: docker build -t tmp .

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,6 @@ playground.xcworkspace
 # Package.resolved
 .build/
 .swiftpm
-Package.resolved
 
 # CocoaPods
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,17 @@ matrix:
     - os: osx
       osx_image: xcode12
       env: SWIFT_VERSION=5.2
+    - os: osx
+      osx_image: xcode13.2
+      env: SWIFT_VERSION=5.6
+services:
+  - docker
 language: generic
 sudo: required
 dist: trusty
 script:
+  # Build & test with xcode-native tools
   - swift build
   - swift test
-
+  # Build & test with Docker
+  - docker build --build-arg SWIFT_VERSION=${SWIFT_VERSION} -t swifty:${SWIFT_VERSION} .

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,8 +1,0 @@
-
-Should be put in a docker.compose when possible
-
-Used to test on Linux. Current only issue appears to be a difference between the default order used for Keys, or possibly some odd behavior around float/double .infinity/.nan
-
-docker build -t swifty .
-docker run --rm swifty
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM swift 
+ARG SWIFT_VERSION
+FROM swift:${SWIFT_VERSION}
 WORKDIR /app
-COPY Package.swift ./
-RUN swift package clean
-RUN swift package update
+COPY Package.swift Package.resolved ./
+RUN swift package --skip-update --force-resolved-versions resolve
 COPY ./ ./
 RUN swift build
 RUN swift test -v

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,43 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "35f9e770f54ce62dd8526470f14c6e137cef3eea",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "c21f7bab5ca8eee0a9998bbd17ca1d0eb45d4688",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "c93f16c25af5770f0d3e6af27c9634640946b068",
+          "version": "9.2.1"
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/Quick/Quick.git",
+        "state": {
+          "branch": null,
+          "revision": "8cce6acd38f965f5baa3167b939f86500314022b",
+          "version": "3.1.2"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Tests/CodableWrappersTests/XCTestManifests.swift
+++ b/Tests/CodableWrappersTests/XCTestManifests.swift
@@ -3,7 +3,7 @@ import XCTest
 #if !canImport(ObjectiveC)
 public func allTests() -> [XCTestCaseEntry] {
     return [
-        testCase(CodableWrappersTests.allTests),
+        testCase(CodableWrappersTests.allTestClasses),
     ]
 }
 #endif


### PR DESCRIPTION
The package build/test fails on linux with different errors for swift 5.2 and 5.6. I did my best to follow the travis docs, but I couldn't test that part myself. `Package.resolved` seems like a lite version of a lock file, so I added it following the conventions of other package managers.