### PR TITLE
Adding positive empty bool case and renaming

### DIFF
--- a/Sources/CodableWrappers/Convenience/EmptyDefaults.swift
+++ b/Sources/CodableWrappers/Convenience/EmptyDefaults.swift
@@ -16,6 +16,12 @@ import UIKit
 public struct EmptyBool: FallbackValueProvider {
     public static var defaultValue: Bool { false }
 }
+typealias NegativeBool = EmptyBool
+
+/// Empty FallbackValueProvider for Bool: true
+public struct PositiveBool: FallbackValueProvider {
+    public static var defaultValue: Bool { true }
+}
 
 /// Empty FallbackValueProvider for String: ""
 public struct EmptyString: FallbackValueProvider {

--- a/Tests/CodableWrappersTests/Decoder/EmptyDefaultsDecodingTests.swift
+++ b/Tests/CodableWrappersTests/Decoder/EmptyDefaultsDecodingTests.swift
@@ -68,6 +68,11 @@ class EmptyDefaultsDecodingTests: QuickSpec, DecodingTestSpec {
 private struct DefaultDecodingModel: Codable, Equatable {
     @FallbackDecoding<EmptyBool>
     var bool: Bool
+    @FallbackDecoding<PositiveBool>
+    var positiveBool: Bool
+    @FallbackDecoding<NegativeBool>
+    var negativeBool: Bool
+
     @FallbackDecoding<EmptyString>
     var string: String
 
@@ -124,9 +129,9 @@ private struct DefaultDecodingModel: Codable, Equatable {
 }
 
 @available(iOS 14.0, *)
-private let testDecodingTestModel = DefaultDecodingModel(bool: true, string: "1", int: 1, int16: 1, int32: 1, int64: 1, Int8: 1, uInt: 1, uInt16: 1, uInt32: 1, uInt64: 1, uInt8: 1, cgFloat: 1, double: 1, float: 1, float16: 1, array: [1], dictionary: ["1":1], set: [1])
+private let testDecodingTestModel = DefaultDecodingModel(bool: true, positiveBool: false, negativeBool: true, string: "1", int: 1, int16: 1, int32: 1, int64: 1, Int8: 1, uInt: 1, uInt16: 1, uInt32: 1, uInt64: 1, uInt8: 1, cgFloat: 1, double: 1, float: 1, float16: 1, array: [1], dictionary: ["1":1], set: [1])
 @available(iOS 14.0, *)
-private let defaultsDecodingTestModel = DefaultDecodingModel(bool: false, string: "", int: 0, int16: 0, int32: 0, int64: 0, Int8: 0, uInt: 0, uInt16: 0, uInt32: 0, uInt64: 0, uInt8: 0, cgFloat: 0.0, double: 0.0, float: 0.0, float16: 0.0, array: [], dictionary: [:], set: [])
+private let defaultsDecodingTestModel = DefaultDecodingModel(bool: false, positiveBool: true, negativeBool: false, string: "", int: 0, int16: 0, int32: 0, int64: 0, Int8: 0, uInt: 0, uInt16: 0, uInt32: 0, uInt64: 0, uInt8: 0, cgFloat: 0.0, double: 0.0, float: 0.0, float16: 0.0, array: [], dictionary: [:], set: [])
 
 private let valuesTestingJSON = """
 {
@@ -154,6 +159,8 @@ private let valuesTestingJSON = """
     ],
     "Int8" : 1,
     "bool" : true,
+    "positiveBool": false,
+    "negativeBool": true,
     "int32" : 1
 }
 """


### PR DESCRIPTION
Hello ! First and foremost: thank you very much; I started doing code of the sort, but this is so much better and more complete! 🎉  Second: This is my first time contributing, so please be gentle 😅 


## Summary

I find the FallbackDecoding with Bool really useful but sometimes I need to default to false and sometimes to true.
So here I added both and added clearer names so that when the bool is "empty" you know which case you are defaulting to.

### Questions

1. I'm not sure I'm placing them in the correct file (`EmptyDefaults.swift`), because all of them there are named `Empty` and these are not, so please let me know where to put it.
2. Also, could you tell me how to run this project? I wanted to contribute but I didn't see any Xcode Project or Workspace and it was a huge barrier to start. I decided to go for it none the less because I tested this code in my own project, but things like your tests, are a mystery I couldn't run. If you tell me I could add a Contributing section in the README with this useful information.