### PR TITLE
Updating thrown Decoding errors to dataCorrupted instead of valueNotFound

### DIFF
--- a/CustomExamples.md
+++ b/CustomExamples.md
@@ -12,8 +12,8 @@ struct IntToStringCoder: StaticCoder {
         let stringValue = try String(from: decoder)
 
         guard let value = Int(stringValue) else {
-            throw DecodingError.valueNotFound(self,  DecodingError.Context(codingPath: decoder.codingPath,
-                                                                           debugDescription: "Expected \(Int.self)) but could not convert \(stringValue) to \(Int.self)"))
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                    debugDescription: "Expected \(Int.self)) but could not convert \(stringValue) to \(Int.self)"))
         }
         return value
     }
@@ -34,8 +34,8 @@ struct ASCIIDataCoder: StaticCoder {
         let dataValue = try Data(from: decoder)
 
         guard let value = String(data: dataValue, encoding: .ascii) else {
-            throw DecodingError.valueNotFound(self,  DecodingError.Context(codingPath: decoder.codingPath,
-                                                                           debugDescription: "Expected \(String.self)) but could not convert \(dataValue) to \(String.self)"))
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                    debugDescription: "Expected \(String.self)) but could not convert \(dataValue) to \(String.self)"))
         }
         return value
     }

--- a/Sources/CodableWrappers/StaticCoders/DataCoding.swift
+++ b/Sources/CodableWrappers/StaticCoders/DataCoding.swift
@@ -17,7 +17,7 @@ public struct Base64DataStaticCoder: StaticCoder {
         guard let value = Data.init(base64Encoded: stringValue) else {
             let debugDescription = "Expected \(Data.self) but could not convert \(stringValue) to Data"
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
-                                                                           debugDescription: debugDescription))
+                                                                    debugDescription: debugDescription))
         }
         return value
     }

--- a/Sources/CodableWrappers/StaticCoders/DataCoding.swift
+++ b/Sources/CodableWrappers/StaticCoders/DataCoding.swift
@@ -16,7 +16,7 @@ public struct Base64DataStaticCoder: StaticCoder {
 
         guard let value = Data.init(base64Encoded: stringValue) else {
             let debugDescription = "Expected \(Data.self) but could not convert \(stringValue) to Data"
-            throw DecodingError.valueNotFound(self,  DecodingError.Context(codingPath: decoder.codingPath,
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
                                                                            debugDescription: debugDescription))
         }
         return value

--- a/Sources/CodableWrappers/StaticCoders/DateCoding.swift
+++ b/Sources/CodableWrappers/StaticCoders/DateCoding.swift
@@ -64,7 +64,7 @@ extension DateFormatterStaticDecoder {
 
         guard let value = dateFormatter.date(from: stringValue) else {
             let description = "Expected \(Data.self) but could not convert \(stringValue) to Data"
-            throw DecodingError.valueNotFound(self,  DecodingError.Context(codingPath: decoder.codingPath,
+            throw DecodingError.f(DecodingError.Context(codingPath: decoder.codingPath,
                                                                            debugDescription: description))
         }
         return value
@@ -123,7 +123,7 @@ extension ISO8601DateFormatterStaticDecoder {
 
         guard let value = iso8601DateFormatter.date(from: stringValue) else {
             let description = "Expected \(Data.self) but could not convert \(stringValue) to Data"
-            throw DecodingError.valueNotFound(self,  DecodingError.Context(codingPath: decoder.codingPath,
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
                                                                            debugDescription: description))
         }
         return value

--- a/Sources/CodableWrappers/StaticCoders/DateCoding.swift
+++ b/Sources/CodableWrappers/StaticCoders/DateCoding.swift
@@ -64,8 +64,8 @@ extension DateFormatterStaticDecoder {
 
         guard let value = dateFormatter.date(from: stringValue) else {
             let description = "Expected \(Data.self) but could not convert \(stringValue) to Data"
-            throw DecodingError.f(DecodingError.Context(codingPath: decoder.codingPath,
-                                                                           debugDescription: description))
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                    debugDescription: description))
         }
         return value
     }
@@ -124,7 +124,7 @@ extension ISO8601DateFormatterStaticDecoder {
         guard let value = iso8601DateFormatter.date(from: stringValue) else {
             let description = "Expected \(Data.self) but could not convert \(stringValue) to Data"
             throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
-                                                                           debugDescription: description))
+                                                                    debugDescription: description))
         }
         return value
     }

--- a/Sources/CodableWrappers/StaticCoders/FloatingPointCoding.swift
+++ b/Sources/CodableWrappers/StaticCoders/FloatingPointCoding.swift
@@ -31,7 +31,7 @@ public struct NonConformingFloatStaticCoder<ValueProvider: NonConformingDecimalV
         case ValueProvider.nan: return Float.nan
         default:
             guard let value = Float(stringValue) else {
-                throw DecodingError.valueNotFound(self,  DecodingError.Context(codingPath: decoder.codingPath,
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
                 debugDescription: "Expected \(Float.self) but could not convert \(stringValue) to Float"))
             }
             return value
@@ -67,7 +67,7 @@ public struct NonConformingDoubleStaticCoder<ValueProvider: NonConformingDecimal
         case ValueProvider.nan: return Double.nan
         default:
             guard let value = Double(stringValue) else {
-                throw DecodingError.valueNotFound(self,  DecodingError.Context(codingPath: decoder.codingPath,
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
                 debugDescription: "Expected \(Double.self) but could not convert \(stringValue) to Float"))
             }
             return value

--- a/Tests/CodableWrappersTests/Decoder/DataDecodingTests.swift
+++ b/Tests/CodableWrappersTests/Decoder/DataDecodingTests.swift
@@ -116,8 +116,8 @@ private struct CustomBase64Coder: StaticCoder {
         let stringValue = try String(from: decoder)
 
         guard let value = Data.init(base64Encoded: stringValue) else {
-            throw DecodingError.valueNotFound(self,  DecodingError.Context(codingPath: decoder.codingPath,
-                                                                           debugDescription: "Expected \(Data.self) but could not convert \(stringValue) to Data"))
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                    debugDescription: "Expected \(Data.self) but could not convert \(stringValue) to Data"))
         }
         return value
     }

--- a/Tests/CodableWrappersTests/Encoder/DataEncodingTests.swift
+++ b/Tests/CodableWrappersTests/Encoder/DataEncodingTests.swift
@@ -127,8 +127,8 @@ private struct CustomBase64Coder: StaticCoder {
         let stringValue = try String(from: decoder)
 
         guard let value = Data.init(base64Encoded: stringValue) else {
-            throw DecodingError.valueNotFound(self,  DecodingError.Context(codingPath: decoder.codingPath,
-                                                                           debugDescription: "Expected \(Data.self) but could not convert \(stringValue) to Data"))
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                    debugDescription: "Expected \(Data.self) but could not convert \(stringValue) to Data"))
         }
         return value
     }


### PR DESCRIPTION
Updating thrown Decoding errors to dataCorrupted instead of valueNotFound

Suggested by @Brett-Best:  https://github.com/GottaGetSwifty/CodableWrappers/issues/33